### PR TITLE
Fix check for enabled mobile data

### DIFF
--- a/src/com/axelby/podax/Helper.java
+++ b/src/com/axelby/podax/Helper.java
@@ -28,7 +28,7 @@ public class Helper {
 			return false;
 		}
 		// check for 3g data turned off
-		if (cm.getActiveNetworkInfo() != null && cm.getActiveNetworkInfo().isConnected()) {
+		if (!netInfo.isConnected()) {
 			Log.d("Podax", "Not downloading because background data is turned off");
 			return false;
 		}


### PR DESCRIPTION
The check for enabled mobile data always returned false because the test
needed to be reversed. As it turns out, the surrounding code had been
refactored such that we can simplify the test by reusing the existing
ConnectivityManager instance and remove the redundant nullity check.

Signed-off-by: Dan Scott dan@coffeecode.net
