### PR TITLE
Silence Cursor warnings during subscription updates

### DIFF
--- a/src/com/axelby/podax/SubscriptionUpdater.java
+++ b/src/com/axelby/podax/SubscriptionUpdater.java
@@ -190,6 +190,7 @@ public class SubscriptionUpdater {
 				serializer.attribute(null, "xmlUrl", sub.getUrl());
 				serializer.endTag(null, "outline");
 			}
+			c.close();
 
 			serializer.endTag(null, "body");
 			serializer.endTag(null, "opml");

--- a/src/com/axelby/podax/UpdateService.java
+++ b/src/com/axelby/podax/UpdateService.java
@@ -85,6 +85,7 @@ public class UpdateService extends IntentService {
 			Cursor c = getContentResolver().query(SubscriptionProvider.URI, projection, null, null, null);
 			while (c.moveToNext())
 				startService(createUpdateSubscriptionIntent(this, c.getInt(0)));
+			c.close();
 		} else if (action.equals(Constants.ACTION_REFRESH_SUBSCRIPTION)) {
 			int subscriptionId = intent.getIntExtra(Constants.EXTRA_SUBSCRIPTION_ID, -1);
 			if (subscriptionId == -1)
@@ -97,6 +98,7 @@ public class UpdateService extends IntentService {
 			Cursor c = getContentResolver().query(PodcastProvider.QUEUE_URI, projection, null, null, null);
 			while (c.moveToNext())
 				startService(createDownloadPodcastIntent(this, c.getInt(0)));
+			c.close();
 		} else if (action.equals(Constants.ACTION_DOWNLOAD_PODCAST)) {
 			int podcastId = intent.getIntExtra(Constants.EXTRA_PODCAST_ID, -1);
 			if (podcastId == -1)


### PR DESCRIPTION
Logcat issues the following warning per podcast subscription when
checking for updates:

"""
CursorWrap Cursor finalized without prior close
"""

By adding explicit close() calls, we can remove this noise from the logs.

Signed-off-by: Dan Scott dan@coffeecode.net
