### PR TITLE
Issue # 86: Display Unicode data in podcast details

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="8"
-        android:targetSdkVersion="15" />
+        android:targetSdkVersion="16" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/src/com/axelby/podax/ui/PodcastDetailFragment.java
+++ b/src/com/axelby/podax/ui/PodcastDetailFragment.java
@@ -171,7 +171,7 @@ public class PodcastDetailFragment extends SherlockFragment implements LoaderMan
 				"a { color: #E59F39 }" +
 				"</style></head>" +
 				"<body style=\"background:black;color:white\">" + podcast.getDescription() + "</body></html>"; 
-		_descriptionView.loadData(html, "text/html", "utf-8");
+		_descriptionView.loadDataWithBaseURL(null, html, "text/html", "utf-8", null);
 		_descriptionView.setBackgroundColor(Color.BLACK);
 
 		_seekbar.setMax(podcast.getDuration());


### PR DESCRIPTION
WebView.loadData() only accepts 'base64' or ASCII; to get UTF-8, we need
to use WebView.loadDataWithBaseURL(). Wacky, but it works.

Also bump targetSdkVersion to 16, per best practices session at I/O.

Signed-off-by: Dan Scott dan@coffeecode.net
