### PR TITLE
scale podcast bitmap for widget

### DIFF
--- a/src/com/axelby/podax/ui/SmallWidgetProvider.java
+++ b/src/com/axelby/podax/ui/SmallWidgetProvider.java
@@ -46,7 +46,10 @@ public class SmallWidgetProvider extends AppWidgetProvider {
 				long subscriptionId = playerState.getSubscriptionId();
 				String imageFilename = SubscriptionCursor.getThumbnailFilename(subscriptionId);
 				if (new File(imageFilename).exists()) {
-					Bitmap bitmap = BitmapFactory.decodeFile(imageFilename);
+					Bitmap origBitmap = BitmapFactory.decodeFile(imageFilename);
+					// scale bitmap down to save memory (needs to be smaller then display size)
+					float density = context.getResources().getDisplayMetrics().density;
+					Bitmap bitmap = Bitmap.createScaledBitmap(origBitmap, (int)density*83, (int)density*83, false);
 					views.setImageViewBitmap(R.id.show_btn, bitmap);
 				} else {
 					Log.d("Podax", "file doesn't exist: " + imageFilename);


### PR DESCRIPTION
- scale podcast image for widget (RemoteViews)
- RemoteViews only can handle images smaller than display size
- previously crashing feed: http://feeds.feedburner.com/raumzeit-podcast-mp3

I discoved this after the update to android 4.1.1
