### PR TITLE
Add ability to limit queue size (by number of tracks or size)

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -87,6 +87,8 @@
     <string name="pref_update_wifi_title">Wi-Fi Only</string>
     <string name="pref_auto_delete">Delete podcasts automatically when playback finishes or you skip to the next podcast. If disabled, the podcast will be added to the bottom of the queue.</string>
     <string name="pref_auto_delete_title">Delete Podcasts Automatically</string>
+    <string name="pref_max_num_podcasts">Maximum number of downloaded podcasts in queue.</string>
+    <string name="pref_max_num_podcasts_title">Limit Number of Downloaded Podcasts</string>
     <string name="pref_anon_usage">Send anonymous usage data to improve Podax.</string>
     <string name="pref_anon_usage_title">Send Usage Data</string>
     <string name="pref_crash_reports">Send error reports to the developers if Podax crashes.</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -12,6 +12,12 @@
             android:key="autoDeletePref"
             android:summary="@string/pref_auto_delete"
             android:title="@string/pref_auto_delete_title" />
+        <EditTextPreference
+            android:defaultValue="1000"
+            android:numeric="integer"
+            android:key="queueMaxNumPodcasts"
+            android:summary="@string/pref_max_num_podcasts"
+            android:title="@string/pref_max_num_podcasts_title" />
     </PreferenceCategory>
     <PreferenceCategory android:title="Debug" >
         <CheckBoxPreference


### PR DESCRIPTION
Application can fill up all available space by downloading podcasts in background.
It would be good to have an option to somehow limit the space taken.
